### PR TITLE
Build Jekyll production in Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .sass-cache
 .jekyll-metadata
 _site
+www

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 RUN mkdir /source
 WORKDIR /source
 ADD . /source
-RUN bundle exec jekyll build --destination /usr/share/nginx/html
+RUN JEKYLL_ENV=production bundle exec jekyll build --destination /usr/share/nginx/html

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,5 +9,12 @@
 
 {{ content }}
 
+{% if jekyll.environment != "production" %}
+  <div class="container">
+    <hr>
+    <p class="text-center"><b>THIS SAYS "HI!" ONLY IN DEVELOPMENT</b></p>
+  </div>
+{% endif %}
+
 </body>
 </html>


### PR DESCRIPTION
This PR enables on-the-fly building of the Jekyll site when building the Docker image. This means two things:
- We do not have to include the duplicate assets and generated html code in our Git repository anymore. The repository only contains the source files.
- We can make use of the `{{jekyll.environment}}` config setting to do things like Mixpanel loading/ignoring in development and production.
