### PR TITLE
Add Pricing page with Pro Support License

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Intercity is a hosting management dashboard.">
   <meta name="keywords" content="web apps, hosting, dashboard, control panel">
-  <meta name="author" content="Firmhouse">
+  <meta name="author" content="Firmhouse BV">
+
+  {% if page.noindex %}
+  <meta name="robots" content="none">
+  {% endif %}
 
   <title>{{page.title}}</title>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,9 +2,9 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Intercity is a hosting management dashboard.">
-  <meta name="keywords" content="web apps, hosting, dashboard, control panel">
-  <meta name="author" content="Firmhouse BV">
+  <meta name="description" content="Intercity is a webbased hosting management dashboard">
+  <meta name="keywords" content="web apps, hosting, dashboard, control panel, heroku, dokku, on-premise, ruby on rails">
+  <meta name="author" content="Firmhouse B.V.">
 
   {% if page.noindex %}
   <meta name="robots" content="none">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -22,7 +22,7 @@
         <li {% if page.path contains "docs" %}class="active"{% endif %}>
           <a href="/docs">Docs</a>
         </li>
-        <li {% if page.path == "support/index.html" %}class="active"{% endif %}  >
+        <li {% if page.path contains "support" %}class="active"{% endif %}  >
           <a href="/support">Pricing</a>
         </li>
       </ul>

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -23,7 +23,7 @@
           <a href="/docs">Docs</a>
         </li>
         <li {% if page.path == "support/index.html" %}class="active"{% endif %}  >
-          <a href="/support">Support</a>
+          <a href="/support">Pricing</a>
         </li>
       </ul>
     </div><!--/.nav-collapse -->

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -22,8 +22,8 @@
         <li {% if page.path contains "docs" %}class="active"{% endif %}>
           <a href="/docs">Docs</a>
         </li>
-        <li {% if page.path == "support/index.md" %}class="active"{% endif %}  >
-          <a href="/support">Get Support</a>
+        <li {% if page.path == "support/index.html" %}class="active"{% endif %}  >
+          <a href="/support">Support</a>
         </li>
       </ul>
     </div><!--/.nav-collapse -->

--- a/css/intercity-io.css
+++ b/css/intercity-io.css
@@ -1,3 +1,7 @@
 .docs-content {
   font-size: 16px;
 }
+
+.support-option .panel-body {
+  min-height: 280px;
+}

--- a/css/intercity-io.css
+++ b/css/intercity-io.css
@@ -1,7 +1,3 @@
 .docs-content {
   font-size: 16px;
 }
-
-.support-option .panel-body {
-  min-height: 280px;
-}

--- a/index.html
+++ b/index.html
@@ -26,4 +26,5 @@ title: "Intercity: Hosting management panel"
       return { 'cta name': $(element).html() }
     }
   )
+  mixpanel.track("Viewed Homepage")
 </script>

--- a/support/buy.html
+++ b/support/buy.html
@@ -1,0 +1,55 @@
+---
+layout: support
+title: "Intercity Plans and Pricing"
+---
+
+<div class="block text-xs-center p-t-0 p-b-md">
+  <h2 class="block-title">Buy a Pro Support License</h2>
+  <h3 class="text-muted">Please fill out the form below and we'll get in touch within a working day.</h3>
+</div>
+
+<div class="block p-t-md">
+  <div class="row">
+    <div class="col-sm-offset-3 col-sm-6">
+      <div class="panel panel-default">
+        <div class="panel-body">
+          <form action="https://formbox.es/Q9mSR6s6Wf9capk3pGCLUtno" method="post">
+            <div class="form-group">
+              <label for="name">Your Name</label>
+              <input type="text" class="form-control" id="name" name="name" placeholder="Michiel Sikkes">
+            </div>
+            <div class="form-group">
+              <label for="email">Your Email</label>
+              <input type="email" class="form-control" id="email" name="email" placeholder="michiel@perfectapps.com">
+            </div>
+            <div class="form-group">
+              <label for="companyName">Your Company</label>
+              <input type="text" class="form-control" id="companyName" name="companyName" placeholder="Perfect Apps">
+            </div>
+            <div class="form-group">
+              <p><b>Where do you want to host your apps?</b></p>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="hostWhere" value="ownServer">Own server / on-premise</input>
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="hostWhere" value="cloudService">Some cloud or VPS service (AWS, DigitalOcean, Rackspace, TransIP, etc.)</input>
+                </label>
+              </div>
+              <div class="radio">
+                <label>
+                  <input type="radio" name="hostWhere" value="managed">I don't know or would like the Intercity team to take care of it</input>
+                </label>
+              </div>
+            </div>
+            <div class="text-center">
+              <button type="submit" class="btn btn-primary btn-lg">Get in touch</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/support/buy.html
+++ b/support/buy.html
@@ -1,6 +1,6 @@
 ---
 layout: support
-title: "Intercity Plans and Pricing"
+title: "Buy a Pro Support License for Intercity"
 ---
 
 <div class="block text-xs-center p-t-0 p-b-md">
@@ -14,6 +14,12 @@ title: "Intercity Plans and Pricing"
       <div class="panel panel-default">
         <div class="panel-body">
           <form action="https://formbox.es/Q9mSR6s6Wf9capk3pGCLUtno" method="post">
+            {% if jekyll.environment == "production" %}
+              <input type="hidden" name="return_to" value="https://intercity.io/support/thank-you.html">
+            {% endif %}
+            {% if jekyll.environment != "production" %}
+              <input type="hidden" name="return_to" value="http://localhost:4000/support/thank-you.html">
+            {% endif %}
             <div class="form-group">
               <label for="name">Your Name</label>
               <input type="text" class="form-control" id="name" name="name" placeholder="Michiel Sikkes">
@@ -53,3 +59,7 @@ title: "Intercity Plans and Pricing"
     </div>
   </div>
 </div>
+
+<script type="text/javascript">
+  mixpanel.track("Viewed Pro Support License")
+</script>

--- a/support/index.html
+++ b/support/index.html
@@ -22,7 +22,7 @@ title: "Intercity Plans and Pricing"
           </ul>
         </div>
         <div class="panel-footer text-center">
-          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default-outline">Install right now</a>
+          <a href="/docs/index.html" class="btn btn-default-outline">Install right now</a>
         </div>
       </div>
     </div>

--- a/support/index.html
+++ b/support/index.html
@@ -39,7 +39,7 @@ title: "Intercity Plans and Pricing"
           </ul>
         </div>
         <div class="panel-footer text-center">
-          <a href="/support/buy.html" class="btn btn-primary">Buy Now</a>
+          <a href="/support/buy.html" class="btn btn-primary btn-lg">Buy Now</a>
         </div>
       </div>
     </div>

--- a/support/index.html
+++ b/support/index.html
@@ -45,3 +45,7 @@ title: "Intercity Plans and Pricing"
     </div>
   </div>
 </div>
+
+<script type="text/javascript">
+  mixpanel.track("Viewed Pricing")
+</script>

--- a/support/index.html
+++ b/support/index.html
@@ -1,42 +1,45 @@
 ---
 layout: support
-title: "Intercity Support"
+title: "Intercity Plans and Pricing"
 ---
 
 <div class="block text-xs-center p-t-0 p-b-0">
-  <h2 class="block-title">Support</h2>
+  <h2 class="block-title">Plans for developers and businesses</h2>
   <h3 class="text-muted">Ask questions about using Intercity and get help setting up your hosting.</h3>
 </div>
 
-<div class="block">
+<div class="block block-angle">
   <div class="row">
-    <div class="col-sm-6 support-option">
+    <div class="col-sm-offset-2 col-sm-4 support-option" style="margin-top: 15px">
       <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title text-center">Premium Support</h3>
-        </div>
         <div class="panel-body">
-          <p>For freelancers, developers, and IT management people in commercial or corporate environments.</p>
-          <p>Get guaranteed response from the Intercity team when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
-          <p>If you want, we can even configure and maintain your private / on-premise Intercity instance for you.</p>
+          <h3 class="m-t-0 text-center">Open Source Install</h3>
+          <p class="text-center text-primary" style="font-size: 40px">Free</p>
+          <ul>
+            <li>Manual install on your server</li>
+            <li>Manage unlimited apps</li>
+            <li>Community support</li>
+          </ul>
         </div>
         <div class="panel-footer text-center">
-          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default btn-primary">See pricing and details</a>
+          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default-outline">Install right now</a>
         </div>
       </div>
     </div>
-    <div class="col-sm-6 support-option">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h3 class="panel-title text-center">Free Support</h3>
-        </div>
+    <div class="col-sm-4 support-option">
+      <div class="panel panel-primary">
         <div class="panel-body">
-          <p>For everyone using Intercity for their own side projects and personal use.</p>
-          <p>Get help from the Intercity developers and other users via GitHub. Have a question, bug report, feature request or documentation improvement? Let us know!</p>
-          <p>Just write an issue on GitHub and we'll answer as quickly as we can.</p>
+          <h3 class="m-t-0 text-primary text-center">Pro Support License</h3>
+          <p class="text-center text-primary" style="font-size: 40px">€200</p>
+          <ul>
+            <li>Install yourself or have us do it</li>
+            <li>Manage unlimited apps</li>
+            <li>Pro support by Intercity team</li>
+            <li>Sleep well knowing app pros are there to back you up</li>
+          </ul>
         </div>
         <div class="panel-footer text-center">
-          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default">Write an Issue on GitHub</a>
+          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-primary">Buy Now</a>
         </div>
       </div>
     </div>

--- a/support/index.html
+++ b/support/index.html
@@ -17,7 +17,7 @@ title: "Intercity Support"
         </div>
         <div class="panel-body">
           <p>For freelancers, developers, and IT management people in commercial or corporate environments.</p>
-          <p>Get guaranteed response times from the Intercity team when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
+          <p>Get guaranteed response from the Intercity team when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
           <p>If you want, we can even configure and maintain your private / on-premise Intercity instance for you.</p>
         </div>
         <div class="panel-footer text-center">

--- a/support/index.html
+++ b/support/index.html
@@ -1,0 +1,44 @@
+---
+layout: support
+title: "Intercity Support"
+---
+
+<div class="block text-xs-center p-t-0 p-b-0">
+  <h2 class="block-title">Support</h2>
+  <h3 class="text-muted">Ask questions about using Intercity and get help setting up your hosting.</h3>
+</div>
+
+<div class="block">
+  <div class="row">
+    <div class="col-sm-6">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title text-center">Premium Support</h3>
+        </div>
+        <div class="panel-body">
+          <p>For freelancers, developers, and IT management people in commercial or corporate environments.</p>
+          <p>Get guaranteed response times when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
+          <p>If you want, we can even configure and maintain your private / on-premise Intercity instance for you.</p>
+        </div>
+        <div class="panel-footer text-center">
+          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default btn-primary">See pricing and details</a>
+        </div>
+      </div>
+    </div>
+    <div class="col-sm-6">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h3 class="panel-title text-center">Free Support</h3>
+        </div>
+        <div class="panel-body">
+          <p>For everyone using Intercity for their own side projects and personal use.</p>
+          <p>Get help from the Intercity developers and other users via GitHub. Have a question, bug report, feature request or documentation improvement? Let us know!</p>
+          <p>Just write an issue on GitHub and we'll answer as quickly as we can.</p>
+        </div>
+        <div class="panel-footer text-center">
+          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-default">Write an Issue on GitHub</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/support/index.html
+++ b/support/index.html
@@ -3,12 +3,12 @@ layout: support
 title: "Intercity Plans and Pricing"
 ---
 
-<div class="block text-xs-center p-t-0 p-b-0">
+<div class="block text-xs-center p-t-0 p-b-md">
   <h2 class="block-title">Plans for developers and businesses</h2>
   <h3 class="text-muted">Ask questions about using Intercity and get help setting up your hosting.</h3>
 </div>
 
-<div class="block block-angle">
+<div class="block p-t-md">
   <div class="row">
     <div class="col-sm-offset-2 col-sm-4 support-option" style="margin-top: 15px">
       <div class="panel panel-default">

--- a/support/index.html
+++ b/support/index.html
@@ -39,7 +39,7 @@ title: "Intercity Plans and Pricing"
           </ul>
         </div>
         <div class="panel-footer text-center">
-          <a href="https://github.com/intercity/intercity-next/issues" class="btn btn-primary">Buy Now</a>
+          <a href="/support/buy.html" class="btn btn-primary">Buy Now</a>
         </div>
       </div>
     </div>

--- a/support/index.html
+++ b/support/index.html
@@ -10,14 +10,14 @@ title: "Intercity Support"
 
 <div class="block">
   <div class="row">
-    <div class="col-sm-6">
+    <div class="col-sm-6 support-option">
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title text-center">Premium Support</h3>
         </div>
         <div class="panel-body">
           <p>For freelancers, developers, and IT management people in commercial or corporate environments.</p>
-          <p>Get guaranteed response times when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
+          <p>Get guaranteed response times from the Intercity team when asking questions and get personal assistance in installing, configuring and setting up your hosting infrastructure with Intercity.</p>
           <p>If you want, we can even configure and maintain your private / on-premise Intercity instance for you.</p>
         </div>
         <div class="panel-footer text-center">
@@ -25,7 +25,7 @@ title: "Intercity Support"
         </div>
       </div>
     </div>
-    <div class="col-sm-6">
+    <div class="col-sm-6 support-option">
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title text-center">Free Support</h3>

--- a/support/index.md
+++ b/support/index.md
@@ -1,4 +1,0 @@
----
-layout: support
-title: "Intercity Support"
----

--- a/support/thank-you.html
+++ b/support/thank-you.html
@@ -1,0 +1,22 @@
+---
+layout: support
+title: "We'll be in touch shortly"
+noindex: true
+---
+
+<div class="block text-xs-center p-t-0 p-b-md">
+  <h2 class="block-title">Buy a Pro Support License</h2>
+  <h3 class="text-muted">Please fill out the form below and we'll get in touch within a working day.</h3>
+</div>
+
+<div class="block p-t-md">
+  <div class="row">
+    <div class="col-sm-offset-3 col-sm-6">
+        <div class="alert alert-success">Thank you for your interest. We'll get back to you within a day.</div>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript">
+  mixpanel.track("Submitted Pro Support License interest")
+</script>

--- a/tour/index.html
+++ b/tour/index.html
@@ -3,8 +3,9 @@ layout: default
 title: "Intercity Tour"
 ---
 
-<div class="block text-xs-center p-t-md">
-  <h1 class="block-title">Tour</h1>
+<div class="block text-xs-center p-t-0">
+  <h2 class="block-title">Tour</h2>
+  <h3 class="text-muted">What's included in Intercity</h3>
 </div>
 
 <div class="block block-bordered-lg">


### PR DESCRIPTION
This renames the Support page to "Pricing" and adds a pricing page with two support options:
- Free support / reference to installing via install guide
- Buy now button for Pro support license that continues to a contact details form

Added:
- New pricing pages
- Mixpanel events for pro support license funnel tracking

Here's three screenshots:

![schermafbeelding 2016-09-05 om 14 11 25](https://cloud.githubusercontent.com/assets/42268/18247420/bd2cc550-7372-11e6-8cc3-81fa52682a2b.png)
![schermafbeelding 2016-09-05 om 14 11 29](https://cloud.githubusercontent.com/assets/42268/18247422/bd314e72-7372-11e6-9f6c-34832ddbc4e1.png)
![schermafbeelding 2016-09-05 om 14 11 31](https://cloud.githubusercontent.com/assets/42268/18247421/bd2f6d00-7372-11e6-9f3a-36091be0bfea.png)
